### PR TITLE
Remove eth0 from interfaces

### DIFF
--- a/br2_external/board/X6100/linux/rootfs-overlay/etc/network/interfaces
+++ b/br2_external/board/X6100/linux/rootfs-overlay/etc/network/interfaces
@@ -1,0 +1,2 @@
+auto lo
+iface lo inet loopback


### PR DESCRIPTION
Device has no eth0 port, but during booting it tries to retrieve IP address through DHCP. This makes boot ~15 seconds longer.